### PR TITLE
Fix for Issue #6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,7 @@ esac
 
 # Initialize the automake subsystem.
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+AM_INIT_AUTOMAKE([1.11 -Wall -Wno-portability -Wno-extra-portability -Werror foreign])
 
 #
 # In case we have a Windows build, we pass a 


### PR DESCRIPTION
Fix build issues arising with recent automake versions as documented
here:
http://lists.gnu.org/archive/html/bug-automake/2012-05/msg00009.html

Also make autoconf stop complaining about non-POSIX variable names
as described here:
http://gnu-automake.7480.n7.nabble.com/Warn-non-POSIX-variable-name-td4931.html
