### PR TITLE
VS2010 build.proj to catch up on ud_itab.py renamed

### DIFF
--- a/BuildVS2010/build.proj
+++ b/BuildVS2010/build.proj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <Target Name="PreBuild">
-    <Exec Command="c:\python27\python.exe itab.py &quot;../docs/x86/optable.xml&quot;" 
+    <Exec Command="c:\python27\python.exe ../scripts/ud_itab.py &quot;../docs/x86/optable.xml&quot; &quot;../libudis86&quot;" 
           WorkingDirectory="../libudis86" />
   </Target>
 


### PR DESCRIPTION
Build script for Windows seems to be behind the changes of itab.py and fails.
Fix this by just updating build.proj.
