### PR TITLE
Fix some problems when building in WebKit

### DIFF
--- a/libudis86/extern.h
+++ b/libudis86/extern.h
@@ -78,7 +78,7 @@ extern const struct ud_operand* ud_insn_opr(const struct ud *u, unsigned int n);
 
 extern int ud_opr_is_sreg(const struct ud_operand *opr);
 
-extern int ud_opr_isgpr(const struct ud_operand *opr);
+extern int ud_opr_is_gpr(const struct ud_operand *opr);
 
 extern const char* ud_lookup_mnemonic(enum ud_mnemonic_code c);
 

--- a/libudis86/syn.c
+++ b/libudis86/syn.c
@@ -104,7 +104,7 @@ ud_syn_rel_target(struct ud *u, struct ud_operand *opr)
  *    returns a negative number and truncates the output.
  */
 int
-ud_asmprintf(struct ud *u, char *fmt, ...)
+ud_asmprintf(struct ud *u, const char *fmt, ...)
 {
   int ret;
   int avail;

--- a/libudis86/syn.h
+++ b/libudis86/syn.h
@@ -36,10 +36,10 @@ extern const char* ud_reg_tab[];
 uint64_t ud_syn_rel_target(struct ud*, struct ud_operand*);
 
 #ifdef __GNUC__
-int ud_asmprintf(struct ud *u, char *fmt, ...) 
+int ud_asmprintf(struct ud *u, const char *fmt, ...)
     __attribute__ ((format (printf, 2, 3)));
 #else
-int ud_asmprintf(struct ud *u, char *fmt, ...);
+int ud_asmprintf(struct ud *u, const char *fmt, ...);
 #endif
 
 void ud_syn_print_addr(struct ud *u, uint64_t addr);


### PR DESCRIPTION
I'm not sure where HAVE_STRING_H is supposed to be defined, but I get a build error when I try to build this [as part of WebKit in Xcode](https://bugs.webkit.org/show_bug.cgi?id=117205). This fix checks if it's defined first.

The other fix is renaming `ud_opr_isgpr` to `ud_opr_is_gpr` in extern.h to match udis86.c.
