### PR TITLE
Ignore operand size in syn_rel_target to fix disasm on 64bit addresses

### DIFF
--- a/libudis86/syn.c
+++ b/libudis86/syn.c
@@ -86,12 +86,13 @@ const char* ud_reg_tab[] =
 uint64_t
 ud_syn_rel_target(struct ud *u, struct ud_operand *opr)
 {
-  const uint64_t trunc_mask = 0xffffffffffffffffull >> (64 - u->opr_mode);
+  const uint64_t trunc_mask = 0xffffffffffffffffull;
   switch (opr->size) {
   case 8 : return (u->pc + opr->lval.sbyte)  & trunc_mask;
   case 16: return (u->pc + opr->lval.sword)  & trunc_mask;
   case 32: return (u->pc + opr->lval.sdword) & trunc_mask;
   default: UD_ASSERT(!"invalid relative offset size.");
+    return 0ull;
   }
 }
 


### PR DESCRIPTION
This patch aims to fix a bug present in r2 that makes relative branch offsets incorrect on 64bit
