### PR TITLE
fix build with automake 1.14

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,6 @@ case "$host_os" in
 esac
 
 # Initialize the automake subsystem.
-AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AM_INIT_AUTOMAKE([1.11 -Wall -Wno-portability -Wno-extra-portability -Werror foreign])
 
 #


### PR DESCRIPTION
apparently automake 1.14 doesn't like multiple calls AM_INIT_AUTOMAKE in configure.ac and aborts on the second call with an error.
