### PR TITLE
Add ud_initialize helper function

### DIFF
--- a/libudis86/extern.h
+++ b/libudis86/extern.h
@@ -36,6 +36,9 @@ extern "C" {
 
 extern void ud_init(struct ud*);
 
+extern void ud_initialize(struct ud*, uint8_t,
+                          unsigned, const uint8_t*, size_t);
+
 extern void ud_set_mode(struct ud*, uint8_t);
 
 extern void ud_set_pc(struct ud*, uint64_t);

--- a/libudis86/udis86.c
+++ b/libudis86/udis86.c
@@ -57,6 +57,22 @@ ud_init(struct ud* u)
 
 
 /* =============================================================================
+ * ud_initialize
+ *    Initializes ud_t object (extended).
+ * =============================================================================
+ */
+extern void
+ud_initialize(struct ud* u, uint8_t m,
+              unsigned v, const uint8_t* buf, size_t len)
+{
+  ud_init(u);
+  ud_set_mode(u, m);
+  ud_set_vendor(u, v);
+  ud_set_input_buffer(u, buf, len);
+}
+
+
+/* =============================================================================
  * ud_disassemble
  *    Disassembles one instruction and returns the number of 
  *    bytes disassembled. A zero means end of disassembly.


### PR DESCRIPTION
Add ud_initialize helper function as it gives us more simple interface to
initialization sequence. Instead of calling:

  ud_init(&ud)

  ud_set_mode(&ud, m);
  ud_set_vendor(&ud, v);
  ud_set_input_buffer(&ud, buf, len);

  ... we can call now:

  ud_initialize(&ud, m, v, buf, len);
