### PR TITLE
libudis86: introduce asmvprintf hook

### DIFF
--- a/libudis86/extern.h
+++ b/libudis86/extern.h
@@ -92,10 +92,16 @@ extern uint64_t ud_insn_sext_imm(const struct ud*, const struct ud_operand*);
 
 extern void ud_set_asm_buffer(struct ud *u, char *buf, size_t size);
 
-extern void ud_set_sym_resolver(struct ud *u, 
-                                const char* (*resolver)(struct ud*, 
+extern void ud_set_sym_resolver(struct ud *u,
+                                const char* (*resolver)(struct ud*,
                                                         uint64_t addr,
                                                         int64_t *offset));
+
+extern void ud_set_asmvprintf_hook(struct ud *u,
+                                   int (*asmvprintf_hook)(struct ud*,
+                                                          enum ud_syn_class,
+                                                          const char *,
+                                                          va_list));
 
 /* ========================================================================== */
 

--- a/libudis86/syn.h
+++ b/libudis86/syn.h
@@ -35,12 +35,20 @@ extern const char* ud_reg_tab[];
 
 uint64_t ud_syn_rel_target(struct ud*, struct ud_operand*);
 
-#ifdef __GNUC__
-int ud_asmprintf(struct ud *u, const char *fmt, ...)
-    __attribute__ ((format (printf, 2, 3)));
-#else
-int ud_asmprintf(struct ud *u, const char *fmt, ...);
-#endif
+int ud_asmvprintf(struct ud *u, const char *fmt, va_list ap);
+
+static inline int ud_asmprintf(struct ud *u, enum ud_syn_class sc, const char *fmt, ...)
+{
+				int ret;
+				va_list ap;
+				va_start(ap, fmt);
+				if (u->asmvprintf_hook)
+								ret = (*u->asmvprintf_hook)(u, sc, fmt, ap);
+				else
+								ret = ud_asmvprintf(u, fmt, ap);
+				va_end(ap);
+				return ret;
+}
 
 void ud_syn_print_addr(struct ud *u, uint64_t addr);
 void ud_syn_print_imm(struct ud* u, const struct ud_operand *op);

--- a/libudis86/types.h
+++ b/libudis86/types.h
@@ -167,6 +167,22 @@ struct ud_operand {
 };
 
 /* -----------------------------------------------------------------------------
+ * enum ud_syn_class - Type of disassembled syntex elements
+ * -----------------------------------------------------------------------------
+ */
+enum ud_syn_class {
+	UD_prefix,
+	UD_opcode,
+	UD_directive,
+	UD_register,
+	UD_immediate,
+	UD_address,
+	UD_operator,
+	UD_opsize,
+	UD_symbol,
+};
+
+/* -----------------------------------------------------------------------------
  * struct ud - The udis86 object.
  * -----------------------------------------------------------------------------
  */
@@ -234,6 +250,11 @@ struct ud
   void *    user_opaque_data;
   struct ud_itab_entry * itab_entry;
   struct ud_lookup_table_list_entry *le;
+
+  /*
+   * Assembly output hook
+   */
+	int (*asmvprintf_hook)(struct ud*, enum ud_syn_class, const char *, va_list);
 };
 
 /* -----------------------------------------------------------------------------

--- a/libudis86/udis86.c
+++ b/libudis86/udis86.c
@@ -313,6 +313,27 @@ ud_set_sym_resolver(struct ud *u, const char* (*resolver)(struct ud*,
 
 
 /* =============================================================================
+ * ud_set_asmvprintf_hook
+ *    Set asmvprintf hook.
+ *
+ *    The asmvprintf hook could be used to implement custom assembly code
+ *    printing procedure with the help of udis86 builtin syntax formatting
+ *    machanism. The most signficant scenario is the syntax highlighting.
+ *
+ *    The function pointer maybe NULL which resets symbol resolution.
+ * =============================================================================
+ */
+void
+ud_set_asmvprintf_hook(struct ud *u,
+											 int (*asmvprintf_hook)(struct ud*,
+																							enum ud_syn_class,
+																							const char *,
+																							va_list))
+{
+				u->asmvprintf_hook = asmvprintf_hook;
+}
+
+/* =============================================================================
  * ud_insn_mnemonic
  *    Return the current instruction mnemonic.
  * =============================================================================


### PR DESCRIPTION
Introduce asmvprintf hook to implement custom assembly code printing
procedure with the help of udis86 builtin syntax formatting machanism.

For syn-intel/att.c code, a syntax element type (enum ud_syn_class)
is passed as the second argument on each calls to asmprintf().

An example of colorized assembly code output is implemented in udcli.c

Signed-off-by: vardyh vardyh.dev@gmail.com
