### PR TITLE
Add standard defines in case __UD_STANDALONE

### DIFF
--- a/libudis86/types.h
+++ b/libudis86/types.h
@@ -44,6 +44,10 @@
 #elif !defined(__UD_STANDALONE__)
 # include <stdio.h>
 # include <inttypes.h>
+#else
+# include <inttypes.h>
+# include <stddef.h>
+# include <stdarg.h>
 #endif /* !__UD_STANDALONE__ */
 
 /* gcc specific extensions */


### PR DESCRIPTION
Defines are required for uint16_t etc., size_t, and va_list in case of
__UD_STANDALONE on linux.  The stddef.h and stdarg.h defines would
otherwise come from stdio.h were it included.
