### PR TITLE
Fix a small compiler issue with a clang based compiler

### DIFF
--- a/libudis86/decode.h
+++ b/libudis86/decode.h
@@ -148,13 +148,13 @@ enum ud_operand_size {
 static inline enum ud_operand_size
 Mx_mem_size(enum ud_operand_size size)
 {
-    return (size >> 8) & 0xff;
+	return (enum ud_operand_size)(((int)size >> 8) & 0xff);
 }
 
 static inline enum ud_operand_size
 Mx_reg_size(enum ud_operand_size size)
 {
-    return size & 0xff;
+	return (enum ud_operand_size)((int)size & 0xff);
 }
 
 /* A single operand of an entry in the instruction table. 


### PR DESCRIPTION
Hi, bcc64 (Embarcadero's clang based windows 64bit compiler) failes with the following error for decode.h.

[bcc64 Error] decode.h(157): cannot initialize return object of type 'enum ud_operand_size' with an rvalue of type 'int'

This pull request fixes this.
