### PR TITLE
Fix duplicate <opr> for sqrtss

### DIFF
--- a/docs/x86/optable.xml
+++ b/docs/x86/optable.xml
@@ -7868,7 +7868,6 @@
         <def>
             <pfx>aso rexr rexx rexb</pfx>
             <opc>/sse=f3 0f 51</opc>
-            <opr>V W</opr>
             <opr>V H W</opr>
             <cpuid>sse avx</cpuid>
         </def>


### PR DESCRIPTION
Commit 88bb68bb46b754f6561b010d75dbf3b2d6fb3900 added avx instructions
but forgot to remove the old <opr> information for the sqrtss
instruction. Let's get rid of it.

Please double check that this is correct, I'm not very familiar with udis86 yet :-)
