### PR TITLE
tests: use bash instead of sh to run difftest.sh

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -65,12 +65,12 @@ oprtest: oprgen.py
 
 .PHONY: difftest
 difftest: oprtest $(builddir)/difftest.sh
-	@sh $(builddir)/difftest.sh
+	@bash $(builddir)/difftest.sh
 
 
 .PHONY: difftest-refup
 difftest-refup: $(builddir)/difftest.sh
-	@sh $(builddir)/difftest.sh refup
+	@bash $(builddir)/difftest.sh refup
 
 
 .PHONY: warn_no_yasm


### PR DESCRIPTION
On Ubuntu, /bin/sh is a symlink to /bin/dash, however difftest.sh uses
bash-specific constructs and fails when run using dash. Therefore, run
this script explicitly using bash.
