### PR TITLE
Fix standalone compilation

### DIFF
--- a/libudis86/udint.h
+++ b/libudis86/udint.h
@@ -26,6 +26,8 @@
 #ifndef _UDINT_H_
 #define _UDINT_H_
 
+#include "types.h"
+
 #ifdef HAVE_CONFIG_H
 # include <config.h>
 #endif /* HAVE_CONFIG_H */


### PR DESCRIPTION
udint.h needs to include types.h in order to get the **UD_STANDALONE**
macro. Otherwise it will think we're in non-standalone mode and fail to
compile in standalone mode.

This fix seems to work for me, please check if it's the right way to do it. (If not, feel free to just fix it in the right way!)
