### PR TITLE
Expose the offset of the modrm byte

### DIFF
--- a/libudis86/decode.c
+++ b/libudis86/decode.c
@@ -313,6 +313,7 @@ modrm(struct ud * u)
 {
     if ( !u->have_modrm ) {
         u->modrm = inp_next( u );
+        u->modrm_offset = (uint8_t) (u->inp_ctr - 1);
         u->have_modrm = 1;
     }
     return u->modrm;

--- a/libudis86/types.h
+++ b/libudis86/types.h
@@ -225,6 +225,7 @@ struct ud
   uint8_t   br_near;
   uint8_t   have_modrm;
   uint8_t   modrm;
+  uint8_t   modrm_offset;
   uint8_t   vex_op;
   uint8_t   vex_b1;
   uint8_t   vex_b2;


### PR DESCRIPTION
This is useful for applications rewriting instructions, for example [Frida](http://www.frida.re/)'s [X86Relocator](https://github.com/frida/frida-gum/blob/master/gum/arch-x86/gumx86relocator.c#L515).
