### PR TITLE
Enable silent rules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ esac
 
 # Initialize the automake subsystem.
 AM_INIT_AUTOMAKE([1.11 -Wall -Wno-portability -Wno-extra-portability -Werror foreign])
+AM_SILENT_RULES([yes])
 
 #
 # In case we have a Windows build, we pass a 


### PR DESCRIPTION
As udis86 depends on 1.11 we can make use of its support for silent rules (which can be overridden by `make V=1` when there's need for inspecting compiler flags and the likes of).
