### PR TITLE
Update ud_opcode.py to also support Python 3.x

### DIFF
--- a/scripts/ud_opcode.py
+++ b/scripts/ud_opcode.py
@@ -25,6 +25,13 @@
 
 import os
 
+# Some compatibility stuff for supporting python 2.x as well as python 3.x
+def itemslist(dict):
+    try:
+        return dict.iteritems() # python 2.x
+    except AttributeError:
+        return list(dict.items()) # python 3.x
+
 class UdInsnDef:
     """An x86 instruction definition
     """
@@ -170,7 +177,7 @@ class UdOpcodeTable:
         return self._TableInfo[self._typ]['size']
 
     def entries(self):
-        return self._entries.iteritems()
+        return itemslist(self._entries)
 
     def numEntries(self):
         return len(self._entries.keys())
@@ -476,7 +483,7 @@ class UdOpcodeTables(object):
         ssemnemonic = insnDef['mnemonic']
         sseopcodes  = insnDef['opcodes']
         # remove vex opcode extensions
-        sseopcexts  = dict([(e, v) for e, v in insnDef['opcexts'].iteritems()
+        sseopcexts  = dict([(e, v) for e, v in itemslist(insnDef['opcexts'])
                                   if not e.startswith('/vex')])
         # strip out avx operands, preserving relative ordering
         # of remaining operands


### PR DESCRIPTION
Hit this on Arch, which uses Python 3 as default interpreter. The scripts should either call `/usr/bin/python2` instead of just `/usr/bin/python` or this script must be updated. 

The proposed change(s) in particular:
- `dict.iteritems()` has been replaced by `dict.items()`, which returns a lazy view instead. `itemslist()` resolves this.
