### PR TITLE
No UD_ATTRIBUTE_PACKED for ud_mnemonic_code

### DIFF
--- a/scripts/ud_itab.py
+++ b/scripts/ud_itab.py
@@ -319,7 +319,7 @@ class UdItabGenerator:
         enum  = "enum ud_mnemonic_code {\n    "
         enum += ",\n    ".join( [ "UD_I%s" % m for m in self.getMnemonicsList() ] )
         enum += ",\n    UD_MAX_MNEMONIC_CODE"
-        enum += "\n} UD_ATTR_PACKED;\n"
+        enum += "\n};\n"
         self.ItabH.write( enum )
         self.ItabH.write( "\n" )
 


### PR DESCRIPTION
I don't think that packing the enum into 16-bit is advantageous in any way, also it doesn't happen on MSVC, for which the macro is defined to be empty. The default of using a 32-bit type for the enum shouldn't change the ud struct's size (at least it doesn't on Clang/GCC for 64-bit), only the offset of the mnemonic member would be aligned to 4 bytes.
