### PR TITLE
compilation fixes for python 3.3. (iteritems has been removed in python ...

### DIFF
--- a/scripts/ud_opcode.py
+++ b/scripts/ud_opcode.py
@@ -170,7 +170,7 @@ class UdOpcodeTable:
         return self._TableInfo[self._typ]['size']
 
     def entries(self):
-        return self._entries.iteritems()
+        return self._entries.items()
 
     def numEntries(self):
         return len(self._entries.keys())
@@ -476,7 +476,7 @@ class UdOpcodeTables(object):
         ssemnemonic = insnDef['mnemonic']
         sseopcodes  = insnDef['opcodes']
         # remove vex opcode extensions
-        sseopcexts  = dict([(e, v) for e, v in insnDef['opcexts'].iteritems()
+        sseopcexts  = dict([(e, v) for e, v in insnDef['opcexts'].items()
                                   if not e.startswith('/vex')])
         # strip out avx operands, preserving relative ordering
         # of remaining operands


### PR DESCRIPTION
Hello @vmt,

I had some difficulties to compile the program.
I modified these lines because it seems that python 3.3.4 (my version of python) does not know "iteritems" but only "items". 

Thanks you for all
