### PR TITLE
add a vexl prefix entry for movdqu to fix issue #85

### DIFF
--- a/docs/x86/optable.xml
+++ b/docs/x86/optable.xml
@@ -8687,13 +8687,13 @@
             <pfx>aso rexr rexx rexb vexl</pfx>
             <opc>/sse=f3 0f 6f</opc>
             <opr>V W</opr>
-            <cpuid>sse2 avx</cpuid>
         </def>
         <def>
-            <pfx>aso rexr rexx rexb</pfx>
+            <pfx>aso rexr rexx rexb vexl</pfx>
             <opc>/sse=f3 0f 7f</opc>
             <opr>W V</opr>
         </def>
+		<cpuid>sse2 avx</cpuid>
     </instruction>
 
     <instruction>


### PR DESCRIPTION
This should fix issue #85 whereby a vexl prefix was missing for movdqu
