### PR TITLE
cppcheck: Expr is always false because 'else if' cond matches previous cond

### DIFF
--- a/libudis86/syn-att.c
+++ b/libudis86/syn-att.c
@@ -157,7 +157,7 @@ ud_translate_att(struct ud *u)
     ud_asmprintf(u,  "lock ");
   if (u->pfx_rep) {
     ud_asmprintf(u, "rep ");
-  } else if (u->pfx_rep) {
+  } else if (u->pfx_repe) {
     ud_asmprintf(u, "repe ");
   } else if (u->pfx_repne) {
     ud_asmprintf(u, "repne ");


### PR DESCRIPTION
... at line 158
