### PR TITLE
Support octal display of machine code in libudis86 and udcli

### DIFF
--- a/libudis86/extern.h
+++ b/libudis86/extern.h
@@ -82,6 +82,8 @@ extern LIBUDIS86_DLLEXTERN uint64_t ud_insn_off(const struct ud*);
 
 extern LIBUDIS86_DLLEXTERN const char* ud_insn_hex(struct ud*);
 
+extern LIBUDIS86_DLLEXTERN const char* ud_insn_oct(struct ud*);
+
 extern LIBUDIS86_DLLEXTERN unsigned int ud_insn_len(const struct ud* u);
 
 extern LIBUDIS86_DLLEXTERN const struct ud_operand* ud_insn_opr(const struct ud *u, unsigned int n);

--- a/libudis86/types.h
+++ b/libudis86/types.h
@@ -189,6 +189,7 @@ struct ud
   void      (*translator)(struct ud*);
   uint64_t  insn_offset;
   char      insn_hexcode[64];
+  char      insn_octcode[128];
 
   /*
    * Assembly output buffer

--- a/libudis86/udis86.c
+++ b/libudis86/udis86.c
@@ -179,6 +179,30 @@ ud_insn_hex(struct ud* u)
 
 
 /* =============================================================================
+ * ud_insn_oct() - Returns octal form of disassembled instruction.
+ * =============================================================================
+ */
+const char* 
+ud_insn_oct(struct ud* u) 
+{
+  u->insn_octcode[0] = 0;
+  if (!u->error) {
+    unsigned int i;
+    const unsigned char *src_ptr = ud_insn_ptr(u);
+    char* src_oct;
+    src_oct = (char*) u->insn_octcode;
+    /* for each byte used to decode instruction */
+    for (i = 0; i < ud_insn_len(u) && i < sizeof(u->insn_octcode) / 4;
+         ++i, ++src_ptr) {
+      sprintf(src_oct, (i > 0 ? " %03o" : "%03o"), *src_ptr & 0xFF);
+      src_oct += (i > 0 ? 4 : 3);
+    }
+  }
+  return u->insn_octcode;
+}
+
+
+/* =============================================================================
  * ud_insn_ptr
  *    Returns a pointer to buffer containing the bytes that were
  *    disassembled.

--- a/udcli/udcli.c
+++ b/udcli/udcli.c
@@ -73,6 +73,7 @@ static char help[] =
   "               hexadecimal representation. Example: 0f 01 ae 00\n"
   "    -noff    : Do not display the offset of instructions.\n"
   "    -nohex   : Do not display the hexadecimal code of instructions.\n"
+  "    -oct     : Display the octal code of instructions.\n"
   "    -h       : Display this help message.\n"
   "    --version: Show version.\n"
   "\n"
@@ -86,6 +87,7 @@ uint64_t o_count = 0;
 unsigned char o_do_count= 0;
 unsigned char o_do_off = 1;
 unsigned char o_do_hex = 1;
+unsigned char o_do_oct = 0;
 unsigned char o_do_x = 0;
 unsigned o_vendor = UD_VENDOR_AMD;
 
@@ -133,7 +135,10 @@ int main(int argc, char **argv)
 		o_do_off = 0;
 	else if (strcmp(*argv,"-nohex") == 0)
 		o_do_hex = 0;
-	else if (strcmp(*argv,"-x") == 0)
+	else if (strcmp(*argv,"-oct") == 0) {
+		o_do_hex = 0;
+		o_do_oct = 1;
+	} else if (strcmp(*argv,"-x") == 0)
 		o_do_x = 1;
 	else if (strcmp(*argv,"-s") == 0)
 		if (--argc) {
@@ -223,6 +228,17 @@ int main(int argc, char **argv)
 			if (o_do_off)
 				printf("%15s -", "");
 			printf("%-16s", hex2);
+		}
+	} else if (o_do_oct) {
+		const char* oct1, *oct2;
+		oct1 = ud_insn_oct(&ud_obj);
+		oct2 = oct1 + 15;
+		printf("%-16.15s %-24s", oct1, ud_insn_asm(&ud_obj));
+		if (strlen(oct1) > 15) {
+			printf("\n");
+			if (o_do_off)
+				printf("%15s  ", "");
+			printf("%s", oct2 + 1 /* skip space */);
 		}
 	} 
 	else printf(" %-24s", ud_insn_asm(&ud_obj));


### PR DESCRIPTION
Since x86 is said to be more of an octal-ish machine code, I thought it might be useful to have an octal (in addition to hex) display available.
