### PR TITLE
Add clac/stac instructions for SMAP

### DIFF
--- a/docs/x86/optable.xml
+++ b/docs/x86/optable.xml
@@ -528,6 +528,13 @@
     </instruction>
 
     <instruction>
+        <mnemonic>clac</mnemonic>
+        <def>
+            <opc>0f 01 /reg=1 /mod=11 /rm=2</opc>
+        </def>
+    </instruction>
+
+    <instruction>
         <mnemonic>clc</mnemonic>
         <def>
             <opc>f8</opc>
@@ -7902,6 +7909,13 @@
             <opc>/sse=f3 0f 51</opc>
             <opr>V H W</opr>
             <cpuid>sse avx</cpuid>
+        </def>
+    </instruction>
+
+    <instruction>
+        <mnemonic>stac</mnemonic>
+        <def>
+            <opc>0f 01 /reg=1 /mod=11 /rm=3</opc>
         </def>
     </instruction>
 


### PR DESCRIPTION
See https://lwn.net/Articles/517475/ for more information about Supervisor
Mode Access Prevention (SMAP):

"Intel has defined a separate "AC" flag that controls the SMAP feature. If
the AC flag is set, SMAP protection is in force; otherwise access to user-
space memory is allowed. Two new instructions (STAC and CLAC) are provided
to manipulate that flag relatively quickly."

This adds support for those two instructions.

http://www.felixcloutier.com/x86/STAC.html
