### PR TITLE
Add rdseed instruction

### DIFF
--- a/docs/x86/optable.xml
+++ b/docs/x86/optable.xml
@@ -8277,6 +8277,16 @@
     </instruction>
 
     <instruction>
+        <mnemonic>rdseed</mnemonic>
+        <def>
+            <pfx>oso rexr rexw rexx rexb</pfx>
+            <opc>0f c7 /mod=11 /reg=7</opc>
+            <opr>R</opr>
+        </def>
+        <cpuid>rdseed</cpuid>
+    </instruction>
+
+    <instruction>
         <mnemonic>vmclear</mnemonic>
         <vendor>intel</vendor>
         <def>


### PR DESCRIPTION
The rdseed instruction is really similar to rdrand, compare:

http://www.felixcloutier.com/x86/RDRAND.html
http://www.felixcloutier.com/x86/RDSEED.html

The only difference is /reg=7 instead of /reg=6.

However, there is still something wrong with the operand decoding for
both instructions:

objdump:

```
 0:   66 0f c7 f3             rdrand %bx
 4:   0f c7 f3                rdrand %ebx
 7:   48 0f c7 f3             rdrand %rbx
 b:   66 0f c7 fb             rdseed %bx
 f:   0f c7 fb                rdseed %ebx
12:   48 0f c7 fb             rdseed %rbx
```

udcli:

```
0000000000000000 660fc7f3         rdrand rbx
0000000000000004 0fc7f3           rdrand rbx
0000000000000007 480fc7f3         rdrand rbx
000000000000000b 660fc7fb         rdseed rbx
000000000000000f 0fc7fb           rdseed rbx
0000000000000012 480fc7fb         rdseed rbx
```

This is still an improvement, however.
