### PR TITLE
Add new instruction ENDBR64 and ENDBR32

### DIFF
--- a/docs/x86/optable.xml
+++ b/docs/x86/optable.xml
@@ -1299,6 +1299,20 @@
     </instruction>
 
     <instruction>
+        <mnemonic>endbr64</mnemonic>
+        <def>
+            <opc>/sse=f3 0f 1e /mod=11 /reg=7 /rm=2 /m=64</opc>
+        </def>
+    </instruction>
+
+    <instruction>
+        <mnemonic>endbr32</mnemonic>
+        <def>
+            <opc>/sse=f3 0f 1e /mod=11 /reg=7 /rm=3 /m=32</opc>
+        </def>
+    </instruction>
+
+    <instruction>
         <mnemonic>enter</mnemonic>
         <def>
             <opc>c8</opc>

--- a/scripts/ud_opcode.py
+++ b/scripts/ud_opcode.py
@@ -387,7 +387,7 @@ class UdOpcodeTables(object):
         # well the opcode table is packed. Also note, /sse must be
         # before /o, because /sse may consume operand size prefix
         # affect the outcome of /o.
-        for ext in ('/mod', '/x87', '/reg', '/rm', '/sse', '/o', '/a', '/m',
+        for ext in ('/sse', '/mod', '/x87', '/reg', '/rm', '/o', '/a', '/m',
                     '/vexw', '/vexl', '/3dnow', '/vendor'):
             if ext in opcexts:
                 opcodes.append(ext + '=' + opcexts[ext])


### PR DESCRIPTION
Intel IBT requires the target of any indirect CALL or JMP instruction
to be the ENDBR instruction;

Besides, fix the collision of /sse and /mod type when build.

Signed-off-by: Wang, Xue xue1.wang@intel.com