### PR TITLE
Ordering of itab.h and itab.c varies between runs and Python versions…

### DIFF
--- a/scripts/ud_opcode.py
+++ b/scripts/ud_opcode.py
@@ -248,7 +248,7 @@ class UdOpcodeTable:
     @classmethod
     def getLabels(cls):
         """Returns a list of all labels"""
-        return [cls._TableInfo[k]['label'] for k in cls._TableInfo.keys()]
+        return sorted([cls._TableInfo[k]['label'] for k in cls._TableInfo.keys()])
 
 
 class UdOpcodeTables(object):
@@ -349,7 +349,8 @@ class UdOpcodeTables(object):
             if tbl not in uniqTables:
                 self._tables.append(tbl)
             uniqTables[tbl] = 1
-            for k, e in tbl.entries():
+            for k in range(tbl.size()):
+                e = tbl.entryAt(k)
                 if isinstance(e, UdOpcodeTable):
                     genTableList(e)
         self._tables = []


### PR DESCRIPTION
… #144 (https://github.com/vmt/udis86/issues/144)

scripts/ud_opcode.py: Working on https://github.com/vmt/udis86/issues/120, because I hadn't realized that someone had already got properly to the root of it, in https://github.com/vmt/udis86/pull/139, I was hampered by the output, specifically itab.h, changing order every time I ran:

UD_OPCODE_DEBUG=1 python3 ../scripts/ud_itab.py ../docs/x86/optable.xml .

... from the libudis86/ directory.  The getLabels change here fixes that to be in a defined ordering.

The mergeSSENONE change fixes the ordering differences I see in itab.c between running the above command and similar with python2, by iterating over each table in the same style as used by genOpcodeTable in class UdItabGenerator in scripts/ud_itab.py.